### PR TITLE
bugfix: incorrect calculation of average

### DIFF
--- a/src/ngx_stream_server_traffic_status_node.c
+++ b/src/ngx_stream_server_traffic_status_node.c
@@ -388,16 +388,18 @@ ngx_stream_server_traffic_status_node_time_queue_amm(
     ngx_stream_server_traffic_status_node_time_queue_t *q,
     ngx_msec_t period)
 {
-    ngx_int_t   i, j, k;
+    ngx_int_t   i, j, k, n;
     ngx_msec_t  x, current_msec;
 
     current_msec = ngx_stream_server_traffic_status_current_msec();
 
     x = period ? (current_msec - period) : 0;
 
-    for (i = q->front, j = 1, k = 0; i != q->rear; i = (i + 1) % q->len, j++) {
+    for (i = q->front, j = 1, k = 0, n = 0; i != q->rear;
+         i = (i + 1) % q->len, j++) {
         if (x < q->times[i].time) {
             k += (ngx_int_t) q->times[i].msec;
+            ++n;
         }
     }
 
@@ -405,7 +407,11 @@ ngx_stream_server_traffic_status_node_time_queue_amm(
         ngx_stream_server_traffic_status_node_time_queue_init(q);
     }
 
-    return (ngx_msec_t) (k / (q->len - 1));
+    if (!n) {
+        return (ngx_msec_t) 0;
+    }
+
+    return (ngx_msec_t) (k / n);
 }
 
 
@@ -414,16 +420,18 @@ ngx_stream_server_traffic_status_node_time_queue_wma(
     ngx_stream_server_traffic_status_node_time_queue_t *q,
     ngx_msec_t period)
 {
-    ngx_int_t   i, j, k;
+    ngx_int_t   i, j, k, n;
     ngx_msec_t  x, current_msec;
 
     current_msec = ngx_stream_server_traffic_status_current_msec();
 
     x = period ? (current_msec - period) : 0;
 
-    for (i = q->front, j = 1, k = 0; i != q->rear; i = (i + 1) % q->len, j++) {
+    for (i = q->front, j = 1, k = 0, n = 0; i != q->rear;
+         i = (i + 1) % q->len, j++) {
         if (x < q->times[i].time) {
             k += (ngx_int_t) q->times[i].msec * j;
+            ++n;
         }
     }
 
@@ -431,8 +439,12 @@ ngx_stream_server_traffic_status_node_time_queue_wma(
         ngx_stream_server_traffic_status_node_time_queue_init(q);
     }
 
+    if (!n) {
+        return (ngx_msec_t) 0;
+    }
+
     return (ngx_msec_t)
-               (k / (ngx_int_t) ngx_stream_server_traffic_status_triangle((q->len - 1)));
+               (k / (ngx_int_t) ngx_stream_server_traffic_status_triangle(n));
 }
 
 


### PR DESCRIPTION
The calculated average will be smaller than the actual value when the number of effective values in the queue is less than  `q->len - 1`.